### PR TITLE
Speed up eigenvalue computation with Scipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(name='sigclust',
       author_email='tkeefe@live.unc.edu',
       packages=['sigclust'],
       install_requires=[
+        'scipy',
         'numpy',
         'pandas',
         'scikit-learn'

--- a/sigclust/soft_thresholding.py
+++ b/sigclust/soft_thresholding.py
@@ -37,13 +37,13 @@ def soft_threshold_ming_yuan(eigenvalues, sig2b):
 
 def _compute_tau(eigenvalues, sig2b):
     """Compute the tau that gives Hanwen Huang's soft thresholded eigenvalues, which
-    maximizes the relative size of the first eigenvalue"""
+    maximizes the relative size of the largest eigenvalue"""
 
     # NOTE: tau is found by searching between 0 and Ming Yuan's tilde_tau.
     tilde_tau = _compute_tilde_tau(eigenvalues, sig2b)
     tau_candidates = np.linspace(0, tilde_tau, 100, endpoint=False)  # using endpoint=False to match Matlab behavior
 
-    criteria = [_relative_size_of_1st_eigenvalue(
+    criteria = [_relative_size_of_largest_eigenvalue(
                    _shift_and_threshold_eigenvalues(eigenvalues, tau, sig2b)
                 ) for tau in tau_candidates]
 
@@ -64,7 +64,7 @@ def _shift_and_threshold_eigenvalues(eigenvalues, tau, sig2b):
     shifted_eigenvalues = eigenvalues - tau
     return np.maximum(shifted_eigenvalues, sig2b)
 
-def _relative_size_of_1st_eigenvalue(eigenvalues):
+def _relative_size_of_largest_eigenvalue(eigenvalues):
     return eigenvalues.max() / eigenvalues.sum()
 
 def estimate_background_noise(data):

--- a/tests/test_sigclust.py
+++ b/tests/test_sigclust.py
@@ -69,6 +69,37 @@ class TestUtilityFunctions(TestCase):
         with self.assertRaises(ValueError):
             sigclust.compute_cluster_index(self.test_data, Series(labels))
 
+    def test_get_eigenvalues_for_d_less_than_n(self):
+        np.random.seed(824)
+        d = 5
+        n = 20
+        data = np.random.multivariate_normal(np.zeros(d), np.diag(np.ones(d)), size=n)
+        assert data.shape[0]==n
+        assert data.shape[1]==d
+        eigenvalues = sigclust.get_eigenvalues(data, covariance_method='sample_covariance')
+        self.assertEqual(len(eigenvalues), d)
+
+    def test_get_eigenvalues_for_d_equals_n(self):
+        np.random.seed(824)
+        d = 5
+        n = 5
+        data = np.random.multivariate_normal(np.zeros(d), np.diag(np.ones(d)), size=n)
+        assert data.shape[0]==n
+        assert data.shape[1]==d
+        eigenvalues = sigclust.get_eigenvalues(data, covariance_method='sample_covariance')
+        self.assertEqual(len(eigenvalues), d)
+
+    def test_get_eigenvalues_for_d_greater_than_n(self):
+        np.random.seed(824)
+        d = 10
+        n = 5
+        data = np.random.multivariate_normal(np.zeros(d), np.diag(np.ones(d)), size=n)
+        assert data.shape[0]==n
+        assert data.shape[1]==d
+        eigenvalues = sigclust.get_eigenvalues(data, covariance_method='sample_covariance')
+        self.assertEqual(len(eigenvalues), d)
+
+
 class TestWeightedFunctions(TestCase):
     """Test weighted functions (mean, cov, etc) by comparing them
     to their normal counterparts using suitably multiplied data."""


### PR DESCRIPTION
Previous method of computing eigenvalues used numpy.linalg.eigvals,
which is fine for d <= n. But for d > n the iterative method results
in complex eigenvalues and even with negative real parts. This can be fixed
with numpy.linalg.eigvalsh, but for d >> n it is best to use the scipy routine
we are using now which specifically focuses on finding the large eigenvalues
(we know that d-n of them will be 0).